### PR TITLE
git-absorb: add git-absorb

### DIFF
--- a/bucket/git-absorb.json
+++ b/bucket/git-absorb.json
@@ -1,0 +1,26 @@
+{
+    "homepage": "https://github.com/tummychow/git-absorb/",
+    "description": "Port of Facebook's hg absorb",
+    "license": "BSD-3-Clause",
+    "version": "0.6.10",
+    "architecture": {
+        "64bit": {
+            "extract_dir": "git-absorb-0.6.10-x86_64-pc-windows-msvc",
+            "bin": "git-absorb.exe",
+            "hash": "706e83c7042fd1177b21316dc37185a6d4e8bd823ea74caf47e9390a5482be6b",
+            "url": "https://github.com/tummychow/git-absorb/releases/download/0.6.10/git-absorb-0.6.10-x86_64-pc-windows-msvc.zip"
+        }
+    },
+    "checkver": {
+        "github": "https://github.com/tummychow/git-absorb/"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "extract_dir": "git-absorb-$version-x86_64-pc-windows-msvc",
+                "bin": "git-absorb.exe",
+                "url": "https://github.com/tummychow/git-absorb/releases/download/$version/git-absorb-$version-x86_64-pc-windows-msvc.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Could find git-absorb in main / extras, so I added it from https://github.com/tummychow/git-absorb because I read this https://andrewlock.net/super-charging-git-rebase-with-git-absorb/